### PR TITLE
add asynchronous status returning

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,25 @@ Set the timeout for each poll by the `every` method, passing a number of ms each
 
 A poll limit can also be set by the `ask` method, just pass a maximum number the poll should call.
 
+### Async Usage
+
+The callback that `awty` takes is also provided a `next` function as an argument. If the function uses the argument, it will wait until the `next` function is called.
+
+Instead of returning, whether or not to stop needs to be provided as an argument to the `next` function.
+
+```js
+var awty = require('awty');
+var poll = awty(function(next) {
+  setTimeout(function() {
+    next(/* `true` if polling should be finished */);
+  }, 100)
+});
+
+poll(function() {
+  console.log('finished polling');
+});
+```
+
 ### Incremental Polls
 
 It possible to increment the timeout after each poll, using the `incr` method it will double the last timeout. Or supplying an number of ms to increment by.

--- a/index.js
+++ b/index.js
@@ -20,8 +20,15 @@ module.exports = function awty(poll) {
       , done;
 
     function run() {
-      var result = poll()
-        , timeout = every
+      var result = poll(next);
+
+      if (poll.length === 0) {
+        next(result);
+      }
+    }
+
+    function next(result) {
+      var timeout = every
         , fin = done;
 
       counter += 1;

--- a/test/awty.tests.js
+++ b/test/awty.tests.js
@@ -47,7 +47,28 @@ describe('awty#()', function() {
   });
 });
 
-describe('awty#ask()', function() { 
+describe('awty#(next)', function() {
+  it('should poll once and callback sucess', function(done) {
+    var poll = awty(function awty_next(next) {
+      setTimeout(function() {
+        next(true);
+      }, 100);
+    })
+      , timeout;
+
+    poll.every(100);
+
+    poll(function(fin) {
+      clearTimeout(timeout);
+      assert.ok(fin);
+      done();
+    });
+
+    timeout = setTimeout(error, 1000 + TIMEOUT_BUFFER);
+  });
+});
+
+describe('awty#ask()', function() {
   it('should set an ask limit', function(done) {
     var poll = awty(function() { return ++i >= 3; })
       , i = 0;


### PR DESCRIPTION
Lets you poll for other callbacks! :)

Done in roughly the same style, no `next()` & `stop()` but rather return the `result` status to `next()`.

Tests could maybe be better, was done quickly for @noopkat's https://github.com/noopkat/avrgirl-arduino
